### PR TITLE
Add test_requires.txt to MANIFEST.in

### DIFF
--- a/app/MANIFEST.in
+++ b/app/MANIFEST.in
@@ -1,7 +1,7 @@
 include LICENSE
 include README.md
 include short_description.txt
-include requirements.txt
+include requirements.txt test_requires.txt
 
 
 recursive-exclude * __pycache__


### PR DESCRIPTION
Installing from the resplendent-0.3.4.tar.gz sdist fails due to missing the test_requires.txt file which is read in setup.py. Adding test_requires.txt to MANIFEST.in will add that file to the sdist.
