### PR TITLE
Fix bug using log_exception()

### DIFF
--- a/app/resplendent/util.py
+++ b/app/resplendent/util.py
@@ -7,5 +7,5 @@ import logging
 from logdecorator import log_exception
 
 exclog = log_exception(  # pylint: disable=invalid-name
-    logging.ERROR, "Error handling function.", on_exceptions=(Exception,), reraise=True
+    "Error handling function.", on_exceptions=(Exception,), reraise=True
 )


### PR DESCRIPTION
The issue seems to be that `log_exception` has a different interface than the other log decorators (you can't specify the log level), notwithstanding the fact the logdecorator documentation  says otherwise.

Not sure why this hasn't affected anybody else.

Addresses an error I see installing `spelling` v0.9.8.2 in Ubuntu with python 3.6:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/spelling/__main__.py", line 99, in run_invocation
    for msg in msg_iter:
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/spelling/check.py", line 45, in check_iter
  File "<frozen importlib._bootstrap>", line 941, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 941, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/resplendent/__init__.py", line 5, in <module>
    from . import filters
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/resplendent/filters/__init__.py", line 5, in <module>
    from . import restructuredtext
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/resplendent/filters/restructuredtext.py", line 7, in <module>
    from resplendent.util import exclog
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/resplendent/util.py", line 10, in <module>
    logging.ERROR, "Error handling function.", on_exceptions=(Exception,), reraise=True
TypeError: __init__() takes 2 positional arguments but 3 positional arguments (and 2 keyword-only arguments) were given
```
